### PR TITLE
Create file and remove centered class

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,15 @@
+{{ define "main" }}
+  <article class="pa3 pa4-ns nested-copy-line-height nested-img">
+    <section class="cf ph3 ph5-l pv3 pv4-l f4 center measure-wide lh-copy mid-gray">
+      {{- .Content -}}
+    </section>
+    <section class="flex-ns flex-wrap justify-around mt5">
+      {{ range .Paginator.Pages }}
+        <div class="relative w-100 w-30-l mb4 bg-white">
+          {{- partial "summary.html" . -}}
+        </div>
+      {{ end }}
+    </section>
+    {{- template "_internal/pagination.html" . -}}
+  </article>
+{{ end }}


### PR DESCRIPTION
adds a template overwrite and removes the centered class. 
Fixes https://github.com/theNewDynamic/gohugo-theme-ananke/issues/158#issuecomment-951895802